### PR TITLE
[COP-1] 회원 탈퇴 로직 구현

### DIFF
--- a/src/application/service/seller/seller.service.spec.ts
+++ b/src/application/service/seller/seller.service.spec.ts
@@ -30,11 +30,9 @@ describe('seller service test ', () => {
     test('주어진 아이디로 이미 회원가입한 판매자가 존재할 경우 에러가 발생한다.', async () => {
       sellerRepository.findOne.calledWith(givenSeller.userId).mockResolvedValue(givenSeller);
 
-      try {
+      await expect(async () => {
         await sut.signUp(givenSignInSeller);
-      } catch (e) {
-        expect(e.message).toEqual("이미 등록된 판매자 아이디");
-      }
+      }).rejects.toThrowError(new Error("이미 등록된 판매자 아이디"));
     });
 
     test('주어진 아이디로 회원가입한 판매자가 존재하지 않을 경우 비밀번호가 암호화되어 정상적으로 등록된다.', async () => {
@@ -138,11 +136,9 @@ describe('seller service test ', () => {
 
       sellerRepository.findOne.calledWith(givenNoSellerUserId).mockResolvedValue(null);
 
-      try {
-        await sut.leave(givenNoSellerUserId);
-      } catch (e) {
-        expect(e.message).toEqual("판매자 아이디에 해당하는 판매자 정보 존재하지 않음");
-      }
+      await expect(async () => {
+        await sut.leave(givenNoSellerUserId)
+      }).rejects.toThrowError(new Error("판매자 아이디에 해당하는 판매자 정보 존재하지 않음"));
     });
 
     test('아이디로 판매자를 조회했을 때 삭제 일자가 존재한다면, 이미 탈퇴한 판매자이므로 에러를 던진다.', async () => {
@@ -155,11 +151,9 @@ describe('seller service test ', () => {
 
       sellerRepository.findOne.calledWith(givenSellerUserId).mockResolvedValue(deletedSeller);
 
-      try {
+      await expect(async () => {
         await sut.leave(deletedSeller.userId);
-      } catch (e) {
-        expect(e.message).toEqual("이미 삭제된 판매자");
-      }
+      }).rejects.toThrowError(new Error("이미 삭제된 판매자"));
     });
 
     test('아이디로 판매자를 조회했을 때 삭제 일자가 존재하지 않는다면 삭제 처리를 진행하고 삭제 일자가 저장된다', async () => {

--- a/src/application/service/seller/seller.service.spec.ts
+++ b/src/application/service/seller/seller.service.spec.ts
@@ -100,11 +100,10 @@ describe('seller service test ', () => {
         deletedAt: null,
       };
 
-      const sellerRepositoryFindOneSpy = jest.spyOn(sellerRepository, 'findOne').mockResolvedValue(savedSeller);
+      const sellerRepositoryFindOneSpy = sellerRepository.findOne.calledWith(savedSeller.userId).mockResolvedValue(savedSeller);
       try {
         const result = await sut.getOne(savedSeller.userId);
         expect(result).toEqual(savedSeller);
-        expect(sellerRepositoryFindOneSpy).toHaveBeenCalledWith(savedSeller);
       } catch (e) {
         // console.error(e);
       }
@@ -121,7 +120,7 @@ describe('seller service test ', () => {
         deletedAt: new Date(),
       };
 
-      const sellerRepositoryFindOneSpy = jest.spyOn(sellerRepository, 'findOne').mockRejectedValue(new Error('deleted seller'));
+      const sellerRepositoryFindOneSpy = sellerRepository.findOne.calledWith(savedSeller.userId).mockResolvedValue(savedSeller);
       try {
         const result = await sut.getOne(savedSeller.userId);
         expect(savedSeller.deletedAt).toBeInstanceOf(Date);
@@ -132,48 +131,55 @@ describe('seller service test ', () => {
     });
   });
 
-  describe('유저 회원 탈퇴 ', () => {
-    test('이미 삭제한 유저', async () => {
-      // 유저 삭제
+  describe('판매자 회원 탈퇴 테스트', () => {
+
+    test('아이디로 판매자를 조회했을 때 판매자 정보가 존재하지 않으면 에러를 던진다.', async () => {
+      const givenNoSellerUserId = "noSellerId"
+
+      sellerRepository.findOne.calledWith(givenNoSellerUserId).mockResolvedValue(null);
+
+      try {
+        await sut.leave(givenNoSellerUserId);
+      } catch (e) {
+        expect(e.message).toEqual("판매자 아이디에 해당하는 판매자 정보 존재하지 않음");
+      }
+    });
+
+    test('아이디로 판매자를 조회했을 때 삭제 일자가 존재한다면, 이미 탈퇴한 판매자이므로 에러를 던진다.', async () => {
+      const givenSellerUserId = givenSeller.userId;
+
       const deletedSeller: Seller = {
-        id: 1,
-        userId: 'test',
-        ceoName: 'testCEO',
-        companyName: 'testCompany',
-        password: 'testPassword',
+        ...givenSeller,
         deletedAt: new Date(),
       };
 
-      const sellerRepositoryFindOneSpy = jest.spyOn(sellerRepository, 'delete').mockRejectedValue(new Error('deleted seller'));
+      sellerRepository.findOne.calledWith(givenSellerUserId).mockResolvedValue(deletedSeller);
 
       try {
-        await sut.delete(deletedSeller.userId);
-        expect(sellerRepositoryFindOneSpy).toThrow();
+        await sut.leave(deletedSeller.userId);
       } catch (e) {
-        // console.error(e);
+        expect(e.message).toEqual("이미 삭제된 판매자");
       }
     });
-    test('유저 삭제 성공', async () => {
-      // 유저 삭제
-      const deletedSeller: Seller = {
-        id: 1,
-        userId: 'test',
-        ceoName: 'testCEO',
-        companyName: 'testCompany',
-        password: 'testPassword',
+
+    test('아이디로 판매자를 조회했을 때 삭제 일자가 존재하지 않는다면 삭제 처리를 진행하고 삭제 일자가 저장된다', async () => {
+      const givenSellerUserId = givenSeller.userId;
+
+      const notDeletedSeller: Seller = {
+        ...givenSeller,
         deletedAt: null,
       };
+      sellerRepository.findOne.calledWith(givenSellerUserId).mockResolvedValue(notDeletedSeller);
 
-      const sellerRepositoryFindOneSpy = jest.spyOn(sellerRepository, 'delete').mockResolvedValue(deletedSeller);
+      const afterDeletedSeller: Seller = {
+        ...givenSeller,
+        deletedAt: new Date(),
+      };
+      sellerRepository.delete.calledWith(givenSellerUserId).mockResolvedValue(afterDeletedSeller);
 
-      try {
-        const result = await sut.delete(deletedSeller.userId);
+      const actualResult = await sut.leave(notDeletedSeller.userId);
 
-        expect(result).toEqual(deletedSeller);
-        expect(sellerRepositoryFindOneSpy).toHaveBeenCalledWith(deletedSeller);
-      } catch (e) {
-        // console.error(e);
-      }
+      expect(actualResult.deletedAt).not.toBeNull()
     });
   });
 });

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -28,7 +28,7 @@ export class SellerService implements ISellerService {
   async signUp(sellerSignUpIn: TSellerSignUpIn): Promise<Seller> {
     const sellerWithSameUserId = await this.sellerRepository.findOne(sellerSignUpIn.userId);
     if (sellerWithSameUserId !== null) {
-      throw Error("이미 등록된 판매자 아이디")
+      throw Error("이미 등록된 판매자 아이디");
     }
 
     const sellerSignUpOut: TSellerSignUpOut = {
@@ -38,13 +38,14 @@ export class SellerService implements ISellerService {
     return await this.sellerRepository.signUp(sellerSignUpOut);
   }
 
-  async delete(userId: string): Promise<Seller> {
-    const oneSeller = await this.sellerRepository.findOne(userId);
-    if (oneSeller.deletedAt) {
-      console.error('이미 삭제된 유저');
-      return null;
+  async leave(userId: string): Promise<Seller> {
+    const seller = await this.sellerRepository.findOne(userId);
+    if (seller === null) {
+      throw Error("판매자 아이디에 해당하는 판매자 정보 존재하지 않음");
     }
-    const deletedSeller = await this.sellerRepository.delete(userId);
-    return deletedSeller;
+    if (seller.deletedAt) {
+      throw Error("이미 삭제된 판매자");
+    }
+    return await this.sellerRepository.delete(userId);
   }
 }

--- a/src/domain/service/seller/seller.service.ts
+++ b/src/domain/service/seller/seller.service.ts
@@ -7,5 +7,5 @@ export interface ISellerService {
   getOne: (userId: string) => Promise<Seller>;
   getAll: () => Promise<Seller[]>;
   signUp: (sellerSignUpIn: TSellerSignUpIn) => Promise<Seller>;
-  delete: (userId: string) => Promise<Seller>;
+  leave: (userId: string) => Promise<Seller>;
 }

--- a/src/infrastructure/service/seller/seller.controller.spec.ts
+++ b/src/infrastructure/service/seller/seller.controller.spec.ts
@@ -8,7 +8,7 @@ class MockSellerService implements ISellerService {
     return Promise.resolve(undefined);
   }
 
-  delete(userId: string): Promise<Seller> {
+  leave(userId: string): Promise<Seller> {
     return Promise.resolve(undefined);
   }
 
@@ -135,10 +135,10 @@ describe('판매자 controller', () => {
         deletedAt: new Date(),
       };
 
-      const sellerServiceDeleteSpy = jest.spyOn(sellerService, 'delete').mockResolvedValue(deletedSeller);
+      const sellerServiceDeleteSpy = jest.spyOn(sellerService, 'leave').mockResolvedValue(deletedSeller);
 
       try {
-        const result = await sellerController.delete(deletedSeller.userId);
+        const result = await sellerController.leave(deletedSeller.userId);
         expect(result).toEqual(deletedSeller);
         // expect(result.deletedAt).toBeInstanceOf(Date);
         expect(sellerServiceDeleteSpy).toHaveBeenCalledWith(deletedSeller);

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, HttpException, HttpStatus, Inject, Param, Post } from '@nestjs/common';
-import { TSellerSignUpRequest, TSellerSignUpResponse } from './seller.dto';
+import { TSellerLeaveResponse, TSellerSignUpRequest, TSellerSignUpResponse } from './seller.dto';
 import { Seller, TSellerSignUpIn } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 
@@ -57,13 +57,12 @@ export class SellerController {
   }
 
   @Delete('/seller/:userId')
-  async delete(@Param('userId') userId: string) {
-    const oneSeller = await this.sellerService.delete(userId);
-    type TSellerResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
-    const response: TSellerResponse = {
-      userId: oneSeller.userId,
-      ceoName: oneSeller.ceoName,
-      companyName: oneSeller.companyName,
+  async leave(@Param('userId') userId: string) {
+    const leavedSeller = await this.sellerService.leave(userId);
+    const response: TSellerLeaveResponse = {
+      userId: leavedSeller.userId,
+      ceoName: leavedSeller.ceoName,
+      companyName: leavedSeller.companyName,
     };
     return response;
   }

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -21,3 +21,5 @@ export class TSellerSignUpRequest {
 }
 
 export type TSellerSignUpResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
+
+export type TSellerLeaveResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;


### PR DESCRIPTION
- 노션 문서 : https://www.notion.so/gweongi/COP-1-a2983d17564f4792a90676c6e29db47a
- jest.spyOn 된 부분에 의해서 전체 테스트를 돌릴 때 findOne 메소드 자체가 스파이 처리 되어 findOne을 사용하는 다른 테스트가 깨지고 있음.
- 일단 임시방편으로 mock으로만 대충 처리함.