### PR TITLE
[COP-3] 유저 정보 조회

### DIFF
--- a/src/application/service/auth/auth.service.spec.ts
+++ b/src/application/service/auth/auth.service.spec.ts
@@ -1,6 +1,5 @@
 import { IAuthService } from '../../../domain/service/auth/auth.service';
 import { AuthService } from './auth.service';
-import { Seller } from '../../../domain/service/seller/seller';
 
 describe('Auth Service test ', () => {
   let testAuthService: IAuthService;

--- a/src/application/service/seller/seller.service.spec.ts
+++ b/src/application/service/seller/seller.service.spec.ts
@@ -1,9 +1,13 @@
 import { SellerService } from './seller.service';
 import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
-import { Seller, TCreateSeller } from '../../../domain/service/seller/seller';
+import { Seller, TSellerFindIn, TCreateSeller, TSellerFindOut } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 
 class MockSellerRepository implements ISellerRepository {
+  findUserInfo(seller: TSellerFindIn): Promise<Seller> {
+    return Promise.resolve(undefined);
+  }
+
   create(seller: TCreateSeller): Promise<Seller> {
     return Promise.resolve(undefined);
   }
@@ -28,6 +32,41 @@ describe('seller service test ', () => {
   beforeEach(async () => {
     sellerRepository = new MockSellerRepository();
     testSellerService = new SellerService(sellerRepository);
+  });
+
+  describe('판매자 정보조회', () => {
+    test('패스워드 일치', async () => {
+
+      const requestInfo: TSellerFindIn = {
+        userId: "testUserId",
+        password: "testPassword"
+      }
+
+      const responseInfo: TSellerFindOut = {
+        userId: "testUserId",
+        password: "testPassword",
+        ceoName: "someGuy",
+        companyName: "someCompany"
+      }
+
+      const responseRepo: Seller = {
+        id: 1,
+        userId: 'test',
+        ceoName: 'testCEO',
+        companyName: 'testCompany',
+        password: 'testPassword',
+        deletedAt: null,
+      }
+
+      const sellerRepositoryFindOneSpy = jest.spyOn(sellerRepository, 'findUserInfo').mockResolvedValue(responseRepo);
+      try {
+        const result: TSellerFindOut = await testSellerService.findUserInfo(requestInfo);
+        expect(result).toEqual(responseInfo);
+        expect(sellerRepositoryFindOneSpy).toHaveBeenCalledWith(requestInfo);
+      } catch (e) {
+        // console.error(e);
+      }
+    });
   });
 
   describe('판매자 회원가입', () => {

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -1,11 +1,33 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { Seller, TCreateSeller } from '../../../domain/service/seller/seller';
-import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
-import { ISellerService } from '../../../domain/service/seller/seller.service';
+import {Inject, Injectable} from '@nestjs/common';
+import {Seller, TCreateSeller, TSellerFindIn, TSellerFindOut} from '../../../domain/service/seller/seller';
+import {ISellerRepository} from '../../../domain/service/seller/seller.repository';
+import {ISellerService} from '../../../domain/service/seller/seller.service';
 
 @Injectable()
 export class SellerService implements ISellerService {
   constructor(@Inject('ISellerRepository') private sellerRepository: ISellerRepository) {}
+
+  async findUserInfo(sellerIn: TSellerFindIn): Promise<TSellerFindOut> {
+    const sellerInfo: Seller = await this.sellerRepository.findUserInfo(sellerIn);
+
+    // 추후에는 실제로 패스워드 인증하는 로직 (로그인 쪽) 맞춰서 하면 될듯 함
+    if (sellerIn.password != sellerInfo.password) {
+      throw Error("Password InCorrect")
+    }
+
+    if (sellerIn.password == sellerInfo.password) {
+      return {
+        userId: sellerInfo.userId,
+        password: sellerInfo.password,
+        ceoName: sellerInfo.ceoName,
+        companyName: sellerInfo.companyName
+      };
+    }
+
+    else {
+      return null;
+    }
+  }
 
   async getOne(userId: string): Promise<Seller> {
     const oneSeller = await this.sellerRepository.findOne(userId);

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -1,7 +1,7 @@
-import {Inject, Injectable} from '@nestjs/common';
-import {Seller, TCreateSeller, TSellerFindIn, TSellerFindOut} from '../../../domain/service/seller/seller';
-import {ISellerRepository} from '../../../domain/service/seller/seller.repository';
-import {ISellerService} from '../../../domain/service/seller/seller.service';
+import { Inject, Injectable } from '@nestjs/common';
+import { Seller, TCreateSeller, TSellerFindIn, TSellerFindOut } from '../../../domain/service/seller/seller';
+import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
+import { ISellerService } from '../../../domain/service/seller/seller.service';
 
 @Injectable()
 export class SellerService implements ISellerService {

--- a/src/domain/service/seller/seller.repository.ts
+++ b/src/domain/service/seller/seller.repository.ts
@@ -1,6 +1,7 @@
-import { Seller, TCreateSeller } from './seller';
+import { Seller, TCreateSeller, TSellerFindIn } from './seller';
 
 export interface ISellerRepository {
+  findUserInfo: (seller: TSellerFindIn) => Promise<Seller>;
   findOne: (userId: string) => Promise<Seller>;
   findAll: () => Promise<Seller[]>;
   create: (seller: TCreateSeller) => Promise<Seller>;

--- a/src/domain/service/seller/seller.service.ts
+++ b/src/domain/service/seller/seller.service.ts
@@ -1,9 +1,10 @@
 // seller service domain 생성하기
 // interface
 
-import { Seller, TCreateSeller } from './seller';
+import { Seller, TCreateSeller, TSellerFindIn, TSellerFindOut } from './seller';
 
 export interface ISellerService {
+  findUserInfo: (seller: TSellerFindIn) => Promise<TSellerFindOut>;
   getOne: (userId: string) => Promise<Seller>;
   getAll: () => Promise<Seller[]>;
   create: (seller: TCreateSeller) => Promise<Seller>;

--- a/src/domain/service/seller/seller.ts
+++ b/src/domain/service/seller/seller.ts
@@ -8,3 +8,6 @@ export type Seller = {
 };
 
 export type TCreateSeller = Pick<Seller, 'userId' | 'ceoName' | 'companyName' | 'password'>;
+
+export type TSellerFindIn = Pick<Seller, 'userId' | 'password'>;
+export type TSellerFindOut = Pick<Seller, 'userId' | 'ceoName' | 'companyName' | 'password'>;

--- a/src/infrastructure/service/seller/seller.controller.spec.ts
+++ b/src/infrastructure/service/seller/seller.controller.spec.ts
@@ -1,6 +1,6 @@
 import { TSellerSignUpRequest } from './seller.dto';
 import { SellerController } from './seller.controller';
-import { Seller, TSellerFindIn, TCreateSeller, TSellerFindOut, TSellerSignUpIn } from '../../../domain/service/seller/seller';
+import { Seller, TSellerFindIn, TSellerFindOut, TSellerSignUpIn } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 
 

--- a/src/infrastructure/service/seller/seller.controller.spec.ts
+++ b/src/infrastructure/service/seller/seller.controller.spec.ts
@@ -1,9 +1,13 @@
 import { CreateSellerRequest } from './seller.dto';
 import { SellerController } from './seller.controller';
-import { Seller, TCreateSeller } from '../../../domain/service/seller/seller';
+import {Seller, TSellerFindIn, TCreateSeller, TSellerFindOut} from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 
 class MockSellerService implements ISellerService {
+  findUserInfo(seller: TSellerFindIn): Promise<Seller> {
+    return Promise.resolve(undefined);
+  }
+
   create(seller: TCreateSeller): Promise<Seller> {
     return Promise.resolve(undefined);
   }
@@ -30,46 +34,49 @@ describe('판매자 controller', () => {
     sellerController = new SellerController(sellerService);
   });
   describe('/seller/:userId (GET)', () => {
-    test('특정 유저 가져오기 ', async () => {
-      const oneSeller: Seller = {
-        id: 1,
-        userId: 'test',
-        ceoName: 'testCEO',
-        companyName: 'testCompany',
-        password: 'testPassword',
-        deletedAt: null,
-      };
+    test('특정 유저 가져오기', async () => {
+      const requestInfo: TSellerFindIn = {
+        userId: "testUser",
+        password: "testPassword"
+      }
 
-      const sellerServiceGetOneSpy = jest.spyOn(sellerService, 'getOne').mockResolvedValue(oneSeller);
+      const responseInfo: TSellerFindOut = {
+        userId: "testUser",
+        password: "testPassword",
+        ceoName: "someGuy",
+        companyName: "someCompany"
+      }
+
+      const sellerServiceGetUserInfoSpy = jest.spyOn(sellerService, 'findUserInfo').mockResolvedValue(responseInfo);
 
       try {
-        const result = await sellerController.getOne(oneSeller.userId);
-        expect(result).toEqual(oneSeller);
-        expect(sellerServiceGetOneSpy).toHaveBeenCalledWith(oneSeller);
+        const result = await sellerController.findUserInfo(requestInfo);
+        expect(result).toEqual(responseInfo);
+        expect(sellerServiceGetUserInfoSpy).toHaveBeenCalledWith(responseInfo);
       } catch (e) {
         // console.error(e);
       }
     });
-    test('삭제된 유저 인 경우 ', async () => {
-      const deletedSeller: Seller = {
-        id: 1,
-        userId: 'test',
-        ceoName: 'testCEO',
-        companyName: 'testCompany',
-        password: 'testPassword',
-        deletedAt: new Date(),
-      };
-
-      const sellerServiceGetOneSpy = jest.spyOn(sellerService, 'getOne').mockResolvedValue(deletedSeller);
-
-      try {
-        const result = await sellerController.getOne(deletedSeller.userId);
-        expect(result.deletedAt).toBeInstanceOf(Date);
-        expect(sellerServiceGetOneSpy).toHaveBeenCalledWith(deletedSeller);
-      } catch (e) {
-        // console.error(e);
-      }
-    });
+    // test('삭제된 유저 인 경우 ', async () => {
+    //   const deletedSeller: Seller = {
+    //     id: 1,
+    //     userId: 'test',
+    //     ceoName: 'testCEO',
+    //     companyName: 'testCompany',
+    //     password: 'testPassword',
+    //     deletedAt: new Date(),
+    //   };
+    //
+    //   const sellerServiceGetOneSpy = jest.spyOn(sellerService, 'getOne').mockResolvedValue(deletedSeller);
+    //
+    //   try {
+    //     const result = await sellerController.getOne(deletedSeller.userId);
+    //     expect(result.deletedAt).toBeInstanceOf(Date);
+    //     expect(sellerServiceGetOneSpy).toHaveBeenCalledWith(deletedSeller);
+    //   } catch (e) {
+    //     // console.error(e);
+    //   }
+    // });
   });
 
   describe('/seller (GET)', () => {

--- a/src/infrastructure/service/seller/seller.controller.spec.ts
+++ b/src/infrastructure/service/seller/seller.controller.spec.ts
@@ -1,6 +1,6 @@
 import { CreateSellerRequest } from './seller.dto';
 import { SellerController } from './seller.controller';
-import {Seller, TSellerFindIn, TCreateSeller, TSellerFindOut} from '../../../domain/service/seller/seller';
+import { Seller, TSellerFindIn, TCreateSeller, TSellerFindOut } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 
 class MockSellerService implements ISellerService {

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -1,11 +1,25 @@
 import { Body, Controller, Delete, Get, HttpException, HttpStatus, Inject, Param, Post } from '@nestjs/common';
-import { CreateSellerRequest } from './seller.dto';
-import { Seller } from '../../../domain/service/seller/seller';
+import { CreateSellerRequest, FindSellerRequest, FindSellerResponse } from './seller.dto';
+import {Seller, TSellerFindIn, TSellerFindOut} from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 
 @Controller()
 export class SellerController {
   constructor(@Inject('ISellerService') private sellerService: ISellerService) {}
+
+  @Get('/seller/:userId')
+  async findUserInfo(@Body() request: FindSellerRequest) {
+    const targetSellerInfo: TSellerFindIn = {
+      ...request,
+    }
+    const resultSellerInfo: TSellerFindOut = await this.sellerService.findUserInfo(targetSellerInfo);
+    const response: FindSellerResponse = {
+      userId: resultSellerInfo.userId,
+      ceoName: resultSellerInfo.ceoName,
+      companyName: resultSellerInfo.companyName,
+    };
+    return response;
+  }
 
   @Get('/seller')
   async getAll() {

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Delete, Get, HttpException, HttpStatus, Inject, Param, Post } from '@nestjs/common';
 import { CreateSellerRequest, FindSellerRequest, FindSellerResponse } from './seller.dto';
-import {Seller, TSellerFindIn, TSellerFindOut} from '../../../domain/service/seller/seller';
+import { Seller, TSellerFindIn, TSellerFindOut } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 
 @Controller()

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -1,5 +1,5 @@
-import {IsString, IsNotEmpty, Matches} from 'class-validator';
-import {Seller} from "../../../domain/service/seller/seller";
+import { IsString, IsNotEmpty, Matches } from 'class-validator';
+import { Seller } from "../../../domain/service/seller/seller";
 
 export class CreateSellerRequest {
   @IsString()

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -1,15 +1,35 @@
-import { IsString, IsInt } from 'class-validator';
+import {IsString, IsNotEmpty, Matches} from 'class-validator';
+import {Seller} from "../../../domain/service/seller/seller";
 
 export class CreateSellerRequest {
   @IsString()
+  @IsNotEmpty()
   userId: string;
 
   @IsString()
+  @IsNotEmpty()
   ceoName: string;
 
   @IsString()
+  @IsNotEmpty()
   companyName: string;
 
   @IsString()
+  @IsNotEmpty()
+  @Matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")
   password: string;
 }
+
+export class FindSellerRequest {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$")
+  password: string;
+}
+
+export type FindSellerResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>
+

--- a/src/infrastructure/service/seller/seller.prisma.repository.ts
+++ b/src/infrastructure/service/seller/seller.prisma.repository.ts
@@ -1,12 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { Seller as SellerEntity } from '@prisma/client';
-import { TCreateSeller } from '../../../domain/service/seller/seller';
+import {Seller, TSellerFindIn, TCreateSeller} from '../../../domain/service/seller/seller';
 import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
 import { PrismaService } from '../../prisma/prisma.service';
 
 @Injectable()
 export class SellerPrismaRepository implements ISellerRepository {
   constructor(private prisma: PrismaService) {}
+
+  async findUserInfo(seller: TSellerFindIn): Promise<Seller> {
+
+    try {
+      // 내부 패스워드 검증 로직 Init, 로그인에 사용되는 로직과 같은 로직을 사용하면 될 듯 합니다.
+      return await this.prisma.seller.findUnique({
+        where: {
+          userId: seller.userId,
+        },
+      });
+    } catch (e) {
+      throw new Error("Password InCorrect")
+    }
+  }
 
   async findOne(userId: string): Promise<SellerEntity | null> {
     return await this.prisma.seller.findUnique({

--- a/src/infrastructure/service/seller/seller.prisma.repository.ts
+++ b/src/infrastructure/service/seller/seller.prisma.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Seller as SellerEntity } from '@prisma/client';
-import {Seller, TSellerFindIn, TCreateSeller} from '../../../domain/service/seller/seller';
+import { Seller, TSellerFindIn, TCreateSeller } from '../../../domain/service/seller/seller';
 import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
 import { PrismaService } from '../../prisma/prisma.service';
 

--- a/src/infrastructure/service/seller/seller.prisma.repository.ts
+++ b/src/infrastructure/service/seller/seller.prisma.repository.ts
@@ -1,10 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Seller as SellerEntity } from '@prisma/client';
-<<<<<<< HEAD
-import { Seller, TSellerFindIn, TCreateSeller } from '../../../domain/service/seller/seller';
-=======
-import { TSellerSignUpOut } from '../../../domain/service/seller/seller';
->>>>>>> develop
+import { Seller, TSellerFindIn, TSellerSignUpOut } from '../../../domain/service/seller/seller';
 import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
 import { PrismaService } from '../../prisma/prisma.service';
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
 import { AppModule } from '../src/infrastructure/app.module';
 
 describe('AppController (e2e)', () => {


### PR DESCRIPTION
## COP-3 유저 정보 조회 #11 

### What I do

- 유저가 본인 스스로의 정보를 조회한다는 생각으로 로직을 작성함
- 유저 정보 조회가 수정을 위한 전단계의 느낌으로 작동한다고 생각했음!

### Plz Help!

- 세부적인 구현사항(세부 로직)은 하나도 못했다고 생각됨
- 아직 In/Out 의 전환점이 정확히 어디가 되어야 하는지 어려움 (일단 Service에서 In으로 받고 Repo에 그대로 넘겨준 뒤에 Repo에서 Seller를 받고 그걸 Service에서 Out에 맞게 포팅한다고 생각했음)
- 테스트코드 쪽에 유저 정보 조회 시 deleteAt이 존재할 경우에 대한 테스트 케이스가 없는데, 이건 애초에 Prisma를 통해서 조회할 때 deleteAt이 존재하는 유저를 조회할 리가 없다고 생각해서 따로 작성하지 않음
- 조회를 위해 Password쪽을 검증하는 로직이 필요한데, 이건 로그인을 구현한 피쳐에서 작성된 로직을 그대로 사용할 생각으로 일단 간단하게 password 일치 불일치로 작성함

아직 많이 헤매고 있는 듯 함...
최대한 빨리 흐름 잘 잡고 이해도 높여보도록 하겠음