### PR TITLE
[COP-3] 판매자 정보조회, 수정 기능 추가

### DIFF
--- a/src/application/service/seller/seller.service.spec.ts
+++ b/src/application/service/seller/seller.service.spec.ts
@@ -313,6 +313,7 @@ describe('seller service test ', () => {
     test('정상적으로 정보를 수정했을 때', async () => {
       const changeInfoIn: ISellerChangeInfoIn = {
         originUserId: 'test',
+        originPassword: 'somePassword',
         userId: 'changedId',
         ceoName: 'changedCeo',
         companyName: 'CoPang',
@@ -352,6 +353,7 @@ describe('seller service test ', () => {
 
       const changeInfoIn: ISellerChangeInfoIn = {
         originUserId: 'test',
+        originPassword: 'somePassword',
         userId: 'someId',
         ceoName: 'guyCEO',
         companyName: 'CoPang',
@@ -378,6 +380,7 @@ describe('seller service test ', () => {
     test('비밀번호를 잘못 입력했을 때', async () => {
       const changeInfoIn: ISellerChangeInfoIn = {
         originUserId: 'test',
+        originPassword: 'somePassword',
         userId: 'someId',
         ceoName: 'guyCEO',
         companyName: 'CoPang',

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -72,23 +72,19 @@ export class SellerService implements ISellerService {
 
   async changeInfo(sellerChangeInfoIn: ISellerChangeInfoIn): Promise<Seller> {
     const seller = await this.sellerRepository.findOne(sellerChangeInfoIn.originUserId);
-    const changeSeller = await this.sellerRepository.findOne(sellerChangeInfoIn.userId);
 
     if (!seller || seller.deletedAt) {
       return null;
     }
 
-    if (changeSeller && changeSeller.deletedAt === null) {
-      throw Error('이미 존재하는 유저 아이디 입니다.');
-    }
-
-    const comparePassword = await this.passwordEncryptor.compare(sellerChangeInfoIn.originPassword, seller.password);
-    if (!comparePassword) {
+    const isPasswordRight = await this.passwordEncryptor.compare(sellerChangeInfoIn.originPassword, seller.password);
+    if (!isPasswordRight) {
       return null;
     }
 
     const sellerChangeInfoOut: TSellerChangeInfoOut = {
       ...sellerChangeInfoIn,
+      userId: seller.userId,
       id: seller.id,
       password: await this.passwordEncryptor.encrypt(sellerChangeInfoIn.password),
     }

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -78,11 +78,11 @@ export class SellerService implements ISellerService {
       return null;
     }
 
-    if (changeSeller !== null) {
-      throw Error("이미 존재하는 유저 아이디 입니다.");
+    if (changeSeller && changeSeller.deletedAt === null) {
+      throw Error('이미 존재하는 유저 아이디 입니다.');
     }
 
-    const comparePassword = await this.passwordEncryptor.compare(seller.password, seller.password);
+    const comparePassword = await this.passwordEncryptor.compare(sellerChangeInfoIn.originPassword, seller.password);
     if (!comparePassword) {
       return null;
     }

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -1,5 +1,12 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { ISellerSignInIn, Seller, TSellerSignUpIn, TSellerSignUpOut } from '../../../domain/service/seller/seller';
+import {
+  ISellerChangeInfoIn,
+  ISellerSignInIn,
+  Seller,
+  TSellerChangeInfoOut,
+  TSellerSignUpIn,
+  TSellerSignUpOut
+} from "../../../domain/service/seller/seller";
 import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 import { IPasswordEncryptor } from '../../../domain/service/auth/encrypt/password.encryptor';
@@ -54,4 +61,39 @@ export class SellerService implements ISellerService {
 
     return true;
   }
+
+  async findUser(userId: string): Promise<Seller> {
+    const seller = await this.sellerRepository.findOne(userId);
+    if (!seller || seller.deletedAt) {
+      return null;
+    }
+    return seller;
+  }
+
+  async changeInfo(sellerChangeInfoIn: ISellerChangeInfoIn): Promise<Seller> {
+    const seller = await this.sellerRepository.findOne(sellerChangeInfoIn.originUserId);
+    const changeSeller = await this.sellerRepository.findOne(sellerChangeInfoIn.userId);
+
+    if (!seller || seller.deletedAt) {
+      return null;
+    }
+
+    if (changeSeller !== null) {
+      throw Error("이미 존재하는 유저 아이디 입니다.");
+    }
+
+    const comparePassword = await this.passwordEncryptor.compare(seller.password, seller.password);
+    if (!comparePassword) {
+      return null;
+    }
+
+    const sellerChangeInfoOut: TSellerChangeInfoOut = {
+      ...sellerChangeInfoIn,
+      id: seller.id,
+      password: await this.passwordEncryptor.encrypt(sellerChangeInfoIn.password),
+    }
+
+    return await this.sellerRepository.update(sellerChangeInfoOut);
+  }
 }
+

--- a/src/domain/service/seller/seller.repository.ts
+++ b/src/domain/service/seller/seller.repository.ts
@@ -1,8 +1,9 @@
-import { Seller, TSellerSignUpOut } from './seller';
+import { Seller, TSellerChangeInfoOut, TSellerSignUpOut } from "./seller";
 
 export interface ISellerRepository {
   findOne: (userId: string) => Promise<Seller>;
   findAll: () => Promise<Seller[]>;
   signUp: (sellerSignUpOutbound: TSellerSignUpOut) => Promise<Seller>;
   delete: (userId: string) => Promise<Seller>;
+  update: (changeSeller: TSellerChangeInfoOut) => Promise<Seller>;
 }

--- a/src/domain/service/seller/seller.service.ts
+++ b/src/domain/service/seller/seller.service.ts
@@ -1,11 +1,13 @@
 // seller service domain 생성하기
 // interface
 
-import { Seller, TSellerSignUpIn, ISellerSignInIn } from './seller';
+import { Seller, TSellerSignUpIn, ISellerSignInIn, ISellerChangeInfoIn } from "./seller";
 
 export interface ISellerService {
   signUp: (sellerSignUpIn: TSellerSignUpIn) => Promise<Seller>;
   signIn: (signInSeller: ISellerSignInIn) => Promise<Seller>;
   signOut: (userId: string) => Promise<boolean>;
   leave: (userId: string) => Promise<Seller>;
+  findUser: (userId: string) => Promise<Seller>;
+  changeInfo: (changeSeller: ISellerChangeInfoIn) => Promise<Seller>;
 }

--- a/src/domain/service/seller/seller.ts
+++ b/src/domain/service/seller/seller.ts
@@ -18,6 +18,7 @@ export interface ISellerSignInIn {
 
 export interface ISellerChangeInfoIn {
   originUserId: string;
+  originPassword: string;
   userId: string;
   ceoName: string;
   companyName: string;

--- a/src/domain/service/seller/seller.ts
+++ b/src/domain/service/seller/seller.ts
@@ -19,7 +19,6 @@ export interface ISellerSignInIn {
 export interface ISellerChangeInfoIn {
   originUserId: string;
   originPassword: string;
-  userId: string;
   ceoName: string;
   companyName: string;
   password: string;

--- a/src/domain/service/seller/seller.ts
+++ b/src/domain/service/seller/seller.ts
@@ -15,3 +15,13 @@ export interface ISellerSignInIn {
   userId: string;
   password: string;
 }
+
+export interface ISellerChangeInfoIn {
+  originUserId: string;
+  userId: string;
+  ceoName: string;
+  companyName: string;
+  password: string;
+}
+
+export type TSellerChangeInfoOut = Pick<Seller, 'id' | 'userId' | 'ceoName' | 'companyName' | 'password'>;

--- a/src/infrastructure/service/auth/auth.interceptor.session.ts
+++ b/src/infrastructure/service/auth/auth.interceptor.session.ts
@@ -25,3 +25,19 @@ export class SessionSignOutInterceptor implements NestInterceptor {
     return next.handle().pipe(tap(() => delete session.user));
   }
 }
+
+@Injectable()
+export class SessionChangeInfoInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const session = request.session;
+
+    return next.handle().pipe(
+      map((data) => {
+        delete session.user
+        session.user = data;
+        return data
+      }),
+    );
+  }
+}

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -1,9 +1,20 @@
 import { Body, Controller, Delete, Get, HttpException, HttpStatus, Inject, Param, Post, Session, UseGuards, UseInterceptors } from '@nestjs/common';
-import { TSellerLeaveResponse, SellerSignInRequest, TSellerSignInResponse, TSellerSignUpRequest, TSellerSignUpResponse } from './seller.dto';
-import { TSellerSignUpIn } from '../../../domain/service/seller/seller';
+import {
+  TSellerLeaveResponse,
+  SellerSignInRequest,
+  TSellerSignInResponse,
+  TSellerSignUpRequest,
+  TSellerSignUpResponse,
+  TSellerFindUserResponse, TSellerChangeInfoRequest, TSellerChangeInfoResponse
+} from "./seller.dto";
+import { ISellerChangeInfoIn, TSellerSignUpIn } from "../../../domain/service/seller/seller";
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 import { AuthHttpGuard } from '../auth/auth.http.guard';
-import { SessionSignInInterceptor, SessionSignOutInterceptor } from '../auth/auth.interceptor.session';
+import {
+  SessionChangeInfoInterceptor,
+  SessionSignInInterceptor,
+  SessionSignOutInterceptor
+} from "../auth/auth.interceptor.session";
 
 @Controller()
 export class SellerController {
@@ -60,4 +71,40 @@ export class SellerController {
       throw new HttpException('UnauthorizedException', HttpStatus.UNAUTHORIZED);
     }
   }
+
+  @UseGuards(AuthHttpGuard)
+  @Post('/seller/findUser')
+  async findUser(@Session() session: Record<string, any>) {
+    const seller = await this.sellerService.findUser(session.user.userId);
+    if (!seller) {
+      throw new HttpException('UnauthorizedException', HttpStatus.UNAUTHORIZED);
+    }
+    const sellerInformation: TSellerFindUserResponse = {
+      userId: seller.userId,
+      companyName: seller.companyName,
+      ceoName: seller.ceoName
+    }
+    return sellerInformation
+  }
+
+  @UseGuards(AuthHttpGuard)
+  @UseInterceptors(SessionChangeInfoInterceptor)
+  @Get('/seller/changeInfo')
+  async changeInfo(@Session() session: Record<string, any>, @Body() changeInfoRequest: TSellerChangeInfoRequest) {
+    const changeSellerInfoIn: ISellerChangeInfoIn = {
+      ...changeInfoRequest,
+      originUserId: session.user.userId
+    }
+    const seller = await this.sellerService.changeInfo(changeSellerInfoIn)
+    if (!seller) {
+      throw new HttpException('UnauthorizedException', HttpStatus.UNAUTHORIZED);
+    }
+    const sellerInformation: TSellerChangeInfoResponse = {
+      userId: seller.userId,
+      companyName: seller.companyName,
+      ceoName: seller.ceoName
+    }
+    return sellerInformation
+  }
+
 }

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -73,7 +73,7 @@ export class SellerController {
   }
 
   @UseGuards(AuthHttpGuard)
-  @Post('/seller/findUser')
+  @Get('/seller/findUser')
   async findUser(@Session() session: Record<string, any>) {
     const seller = await this.sellerService.findUser(session.user.userId);
     if (!seller) {
@@ -89,7 +89,7 @@ export class SellerController {
 
   @UseGuards(AuthHttpGuard)
   @UseInterceptors(SessionChangeInfoInterceptor)
-  @Get('/seller/changeInfo')
+  @Post('/seller/changeInfo')
   async changeInfo(@Session() session: Record<string, any>, @Body() changeInfoRequest: TSellerChangeInfoRequest) {
     const changeSellerInfoIn: ISellerChangeInfoIn = {
       ...changeInfoRequest,

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -56,6 +56,11 @@ export class TSellerChangeInfoRequest {
   @IsNotEmpty()
   @Matches('^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$')
   password: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches('^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$')
+  originPassword: string;
 }
 
 export type TSellerChangeInfoResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -42,10 +42,6 @@ export type TSellerFindUserResponse = Pick<Seller, 'userId' | 'ceoName' | 'compa
 export class TSellerChangeInfoRequest {
   @IsString()
   @IsNotEmpty()
-  userId: string;
-
-  @IsString()
-  @IsNotEmpty()
   ceoName: string;
 
   @IsString()

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -36,3 +36,27 @@ export class SellerSignInRequest {
 export type TSellerSignInResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
 
 export type TSellerLeaveResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
+
+export type TSellerFindUserResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
+
+export class TSellerChangeInfoRequest {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  ceoName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  companyName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches('^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$')
+  password: string;
+}
+
+export type TSellerChangeInfoResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
+

--- a/src/infrastructure/service/seller/seller.prisma.repository.ts
+++ b/src/infrastructure/service/seller/seller.prisma.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Seller as SellerEntity } from '@prisma/client';
-import { TSellerSignUpOut } from '../../../domain/service/seller/seller';
+import { TSellerChangeInfoOut, TSellerSignUpOut } from "../../../domain/service/seller/seller";
 import { ISellerRepository } from '../../../domain/service/seller/seller.repository';
 import { PrismaService } from '../../prisma/prisma.service';
 
@@ -41,4 +41,20 @@ export class SellerPrismaRepository implements ISellerRepository {
       },
     });
   }
+
+  async update(changeSeller: TSellerChangeInfoOut): Promise<SellerEntity> {
+    return await this.prisma.seller.update({
+      where: {
+        id: changeSeller.id,
+      },
+      data: {
+        userId: changeSeller.userId,
+        ceoName: changeSeller.ceoName,
+        companyName: changeSeller.companyName,
+        password: changeSeller.password,
+        updatedAt: new Date(),
+      },
+    });
+  }
+
 }


### PR DESCRIPTION
# #5 판매자 정보 조회와 수정 기능 추가

## About
### 정보 조회
- 정보 조회는 전에 논의되었던대로, 비밀번호를 거치지 않고 바로 세션을 통해 조회할 수 있게끔 조치했습니다.
- 단, 비밀번호까지 바로 다 줘버리는 것은 아닌 것 같아 비밀번호를 제외한 정보를 노출시키도록 조치했습니다.

### 정보 수정
- 정보 수정의 경우, 민감하게 작용해야 하는 로직이라 판단하여 수정될 정보와 함께 비밀번호를 받도록 구성하였습니다.
- 정보 수정에 필요한 기존 아이디 조회는 세션을 통해 받도록 구성하였습니다.
- 정보 수정의 요청이 들어왔을 때, 비밀번호를 체크하고, 변경을 요청한 아이디가 이미 존재하는지 판단하도록 구성하였습니다.
- 세션에 유저의 정보가 저장되어 있기 때문에, 모든 작업이 끝난 뒤에는 기존의 세션 정보를 삭제하고 새로 등록하도록 구성하였습니다.

### 테스트 코드
- 정보 조회는 Repo의 findOne 메소드를 검증하는 절차와 동일하게 구성하였습니다.
- 정보 수정의 경우 정상처리, 비밀번호 오류, 존재하는 아이디로의 변경 요청 총 3개로 구성해보았습니다.

### Etc
- Develop 브렌치 새로 Pull 받았을 때 일부 통일되지 않은 컨벤션이 보였는데 일단 그대로 뒀습니다. 추후 수정이 필요할 듯 합니다. (T, I 혼용 및 미사용 등등)

<br><br/>

테스트 코드 쪽이 상당히 난잡한데, 이것저것 피드백 주세용 감사합니다.


