### PR TITLE
[COP-6] 판매자의 판매 물품 조회 

### DIFF
--- a/src/application/service/seller/seller.service.spec.ts
+++ b/src/application/service/seller/seller.service.spec.ts
@@ -14,6 +14,7 @@ import {
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 import { IPasswordEncryptor } from '../../../domain/service/auth/encrypt/password.encryptor';
 import { CoPangException, EXCEPTION_STATUS } from '../../../domain/common/exception';
+import { PAGING_MAX_NUMBER } from '../../../domain/common/const';
 
 describe('seller service test ', () => {
   const sellerRepository: MockProxy<ISellerRepository> = mock<ISellerRepository>();
@@ -413,7 +414,7 @@ describe('seller service test ', () => {
       const result = await sut.findProduct(successCondition);
 
       await expect(result.currentPageNum).toEqual(successCondition.pageNum);
-      await expect(result.totalPageNum).toEqual(Math.round(successCondition.pageNum / 20) + 1);
+      await expect(result.totalPageNum).toEqual(Math.round(successCondition.pageNum / PAGING_MAX_NUMBER) + 1);
     });
 
     test('판매자가 물품 조회시 order에 잘못된 값을 기입하여 실패한 경우', async () => {
@@ -510,7 +511,7 @@ describe('seller service test ', () => {
       const result = await sut.searchProduct(successCondition);
 
       await expect(result.currentPageNum).toEqual(successCondition.pageNum);
-      await expect(result.totalPageNum).toEqual(Math.round(successCondition.pageNum / 20) + 1);
+      await expect(result.totalPageNum).toEqual(Math.round(successCondition.pageNum / PAGING_MAX_NUMBER) + 1);
     });
 
     test('판매자가 물품 조회시 text에 아무것도 입력하지 않았을 경우', async () => {

--- a/src/application/service/seller/seller.service.spec.ts
+++ b/src/application/service/seller/seller.service.spec.ts
@@ -8,7 +8,6 @@ import {
   ISellerChangeInfoIn,
   TSellerChangeInfoOut,
   TSellerFindProductIn,
-  TSellerSearchProductIn,
   SellerProduct,
 } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
@@ -389,27 +388,61 @@ describe('seller service test ', () => {
   });
 
   describe('판매자 물품 조회', () => {
+    const products: SellerProduct[] = [
+      {
+        id: 1,
+        sellerId: 1,
+        productId: 1,
+        price: 1000,
+        count: 50,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      },
+      {
+        id: 2,
+        sellerId: 1,
+        productId: 1,
+        price: 1000,
+        count: 50,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      },
+      {
+        id: 3,
+        sellerId: 1,
+        productId: 1,
+        price: 1000,
+        count: 50,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      },
+      {
+        id: 4,
+        sellerId: 1,
+        productId: 1,
+        price: 1000,
+        count: 50,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      },
+    ];
+
     test('판매자가 물품 조회를 성공했을 경우', async () => {
       const successCondition: TSellerFindProductIn = {
         sellerId: 1,
+        text: '',
         order: 'asc',
         sortBy: 'id',
         pageNum: 1,
+        take: PAGING_MAX_NUMBER,
       };
 
-      const products: SellerProduct[] = [
-        {
-          id: 1,
-          sellerId: 1,
-          productId: 1,
-          price: 1000,
-          count: 50,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ];
-      jest.spyOn(productRepository, 'findAllWithSellerAndCount').mockResolvedValue([products.length, products]);
+      jest.spyOn(productRepository, 'findAllWithSeller').mockResolvedValue(products);
+      jest.spyOn(productRepository, 'findAllWithSellerCount').mockResolvedValue(products.length);
 
       const result = await sut.findProduct(successCondition);
 
@@ -417,166 +450,33 @@ describe('seller service test ', () => {
       await expect(result.totalPageNum).toEqual(Math.round(successCondition.pageNum / PAGING_MAX_NUMBER) + 1);
     });
 
-    test('판매자가 물품 조회시 order에 잘못된 값을 기입하여 실패한 경우', async () => {
-      const failCondition: TSellerFindProductIn = {
+    test('판매자가 물품 조회시 pageNum이 0을 입력하여 default 으로 호출 성공한 경우 ', async () => {
+      const successCondition: TSellerFindProductIn = {
         sellerId: 1,
-        order: 'ascError',
-        sortBy: 'id',
-        pageNum: 1,
-      };
-
-      await expect(async () => {
-        await sut.findProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_ORDER_OPTION_ERROR));
-    });
-
-    test('판매자가 물품 조회시 sortBy에 잘못된 값을 기입하여 실패한 경우', async () => {
-      const failCondition: TSellerFindProductIn = {
-        sellerId: 1,
-        order: 'desc',
-        sortBy: 'iderror',
-        pageNum: 1,
-      };
-
-      await expect(async () => {
-        await sut.findProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_SORT_BY_OPTION_ERROR));
-    });
-
-    test('판매자가 물품 조회시 pageNum이 0을 입력하여 실패한 경우', async () => {
-      const failCondition: TSellerFindProductIn = {
-        sellerId: 1,
+        text: '',
         order: 'desc',
         sortBy: 'id',
         pageNum: 0,
+        take: PAGING_MAX_NUMBER,
       };
 
-      await expect(async () => {
-        await sut.findProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR));
-    });
+      jest.spyOn(productRepository, 'findAllWithSeller').mockResolvedValue(products);
+      jest.spyOn(productRepository, 'findAllWithSellerCount').mockResolvedValue(products.length);
 
-    test('판매자가 물품 조회시 현재 페이지 숫자가 전체 페이지 수 보다 커서 실패한 경우', async () => {
-      const failCondition: TSellerFindProductIn = {
-        sellerId: 1,
-        order: 'desc',
-        sortBy: 'id',
-        pageNum: 2,
-      };
+      const result = await sut.findProduct(successCondition);
 
-      const products: SellerProduct[] = [
-        {
-          id: 1,
-          sellerId: 1,
-          productId: 1,
-          price: 1000,
-          count: 50,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ];
-      jest.spyOn(productRepository, 'findAllWithSellerAndCount').mockResolvedValue([products.length, products]);
-
-      await expect(async () => {
-        await sut.findProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR));
-    });
-  });
-
-  describe('판매자 물품 검색 조회', () => {
-    test('판매자가 물품 조회를 성공했을 경우', async () => {
-      const successCondition: TSellerSearchProductIn = {
-        sellerId: 1,
-        text: '노트북',
-        order: 'asc',
-        sortBy: 'id',
-        pageNum: 1,
-      };
-
-      const products: SellerProduct[] = [
-        {
-          id: 1,
-          sellerId: 1,
-          productId: 1,
-          price: 1000,
-          count: 50,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ];
-      jest.spyOn(productRepository, 'findSearchWithSellerAndCount').mockResolvedValue([products.length, products]);
-
-      const result = await sut.searchProduct(successCondition);
-
-      await expect(result.currentPageNum).toEqual(successCondition.pageNum);
+      await expect(result.currentPageNum).toEqual(1);
       await expect(result.totalPageNum).toEqual(Math.round(successCondition.pageNum / PAGING_MAX_NUMBER) + 1);
     });
 
-    test('판매자가 물품 조회시 text에 아무것도 입력하지 않았을 경우', async () => {
-      const failCondition: TSellerSearchProductIn = {
+    test('판매자가 물품 조회시 take 수를 0개 이하 일시 default 으로 호출 성공.', async () => {
+      const successCondition: TSellerFindProductIn = {
         sellerId: 1,
         text: '',
-        order: 'asc',
-        sortBy: 'id',
-        pageNum: 1,
-      };
-
-      await expect(async () => {
-        await sut.searchProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.SEARCH_STRING_EMPTY));
-    });
-
-    test('판매자가 물품 조회시 order에 잘못된 값을 기입하여 실패한 경우', async () => {
-      const failCondition: TSellerSearchProductIn = {
-        sellerId: 1,
-        text: '노트북',
-        order: 'ascError',
-        sortBy: 'id',
-        pageNum: 1,
-      };
-
-      await expect(async () => {
-        await sut.searchProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_ORDER_OPTION_ERROR));
-    });
-
-    test('판매자가 물품 조회시 sortBy에 잘못된 값을 기입하여 실패한 경우', async () => {
-      const failCondition: TSellerSearchProductIn = {
-        sellerId: 1,
-        text: '노트북',
-        order: 'desc',
-        sortBy: 'iderror',
-        pageNum: 1,
-      };
-
-      await expect(async () => {
-        await sut.searchProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_SORT_BY_OPTION_ERROR));
-    });
-
-    test('판매자가 물품 조회시 pageNum이 0을 입력하여 실패한 경우', async () => {
-      const failCondition: TSellerSearchProductIn = {
-        sellerId: 1,
-        text: '노트북',
         order: 'desc',
         sortBy: 'id',
-        pageNum: 0,
-      };
-
-      await expect(async () => {
-        await sut.searchProduct(failCondition);
-      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR));
-    });
-
-    test('판매자가 물품 조회시 현재 페이지 숫자가 전체 페이지 수 보다 커서 실패한 경우', async () => {
-      const failCondition: TSellerSearchProductIn = {
-        sellerId: 1,
-        text: '노트북',
-        order: 'desc',
-        sortBy: 'id',
-        pageNum: 2,
+        pageNum: 1,
+        take: 0,
       };
 
       const products: SellerProduct[] = [
@@ -591,10 +491,71 @@ describe('seller service test ', () => {
           deletedAt: null,
         },
       ];
-      jest.spyOn(productRepository, 'findAllWithSellerAndCount').mockResolvedValue([products.length, products]);
+      jest.spyOn(productRepository, 'findAllWithSeller').mockResolvedValue(products);
+      jest.spyOn(productRepository, 'findAllWithSellerCount').mockResolvedValue(products.length);
+
+      const result = await sut.findProduct(successCondition);
+
+      await expect(result.products.length).toBeGreaterThanOrEqual(0);
+    });
+
+    test('판매자가 물품 조회시 order에 잘못된 값을 기입하여 실패한 경우', async () => {
+      const failCondition: TSellerFindProductIn = {
+        sellerId: 1,
+        text: '',
+        order: 'ascError',
+        sortBy: 'id',
+        pageNum: 1,
+        take: PAGING_MAX_NUMBER,
+      };
 
       await expect(async () => {
-        await sut.searchProduct(failCondition);
+        await sut.findProduct(failCondition);
+      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_ORDER_OPTION_ERROR));
+    });
+
+    test('판매자가 물품 조회시 sortBy에 잘못된 값을 기입하여 실패한 경우', async () => {
+      const failCondition: TSellerFindProductIn = {
+        sellerId: 1,
+        text: '',
+        order: 'desc',
+        sortBy: 'iderror',
+        pageNum: 1,
+        take: PAGING_MAX_NUMBER,
+      };
+
+      await expect(async () => {
+        await sut.findProduct(failCondition);
+      }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_SORT_BY_OPTION_ERROR));
+    });
+
+    test('판매자가 물품 조회시 현재 페이지 숫자가 전체 페이지 수 보다 커서 실패한 경우', async () => {
+      const failCondition: TSellerFindProductIn = {
+        sellerId: 1,
+        text: '',
+        order: 'desc',
+        sortBy: 'id',
+        pageNum: 2,
+        take: PAGING_MAX_NUMBER,
+      };
+
+      const products: SellerProduct[] = [
+        {
+          id: 1,
+          sellerId: 1,
+          productId: 1,
+          price: 1000,
+          count: 50,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        },
+      ];
+      jest.spyOn(productRepository, 'findAllWithSeller').mockResolvedValue(products);
+      jest.spyOn(productRepository, 'findAllWithSellerCount').mockResolvedValue(products.length);
+
+      await expect(async () => {
+        await sut.findProduct(failCondition);
       }).rejects.toThrowError(new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR));
     });
   });

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -1,9 +1,14 @@
 import { Inject, Injectable } from '@nestjs/common';
 import {
   ISellerChangeInfoIn,
+  ISellerFindProductPaging,
   ISellerSignInIn,
   Seller,
   TSellerChangeInfoOut,
+  TSellerFindProductIn,
+  TSellerFindProductOut,
+  TSellerSearchProductIn,
+  TSellerSearchProductOut,
   TSellerSignUpIn,
   TSellerSignUpOut,
 } from '../../../domain/service/seller/seller';
@@ -20,6 +25,10 @@ export class SellerService implements ISellerService {
     @Inject('IProductRepository') private productRepository: IProductRepository,
     @Inject('IPasswordEncryptor') private passwordEncryptor: IPasswordEncryptor,
   ) {}
+
+  private readonly MAX_NUMBER: number = 20;
+  private readonly SORT_BY: string[] = ['id', 'price', 'createdAt'];
+  private readonly ORDER: string[] = ['asc', 'desc'];
 
   async signUp(sellerSignUpIn: TSellerSignUpIn): Promise<Seller> {
     const sellerWithSameUserId = await this.sellerRepository.findOne(sellerSignUpIn.userId);
@@ -113,5 +122,93 @@ export class SellerService implements ISellerService {
     };
 
     return await this.sellerRepository.update(sellerChangeInfoOut);
+  }
+
+  async findProduct(condition: TSellerFindProductIn): Promise<ISellerFindProductPaging> {
+    const sellerId = condition.sellerId;
+    const sortBy = condition.sortBy;
+    const order = condition.order;
+    const pageNum = condition.pageNum - 1;
+
+    if (!this.SORT_BY.includes(sortBy)) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_SORT_BY_OPTION_ERROR);
+    }
+
+    if (!this.ORDER.includes(order)) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_ORDER_OPTION_ERROR);
+    }
+
+    if (pageNum < 0) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR);
+    }
+
+    const repositoryCondition: TSellerFindProductOut = {
+      sellerId: sellerId,
+      sortBy: sortBy,
+      order: order,
+      skip: pageNum * this.MAX_NUMBER,
+      take: this.MAX_NUMBER,
+    };
+    const [count, allProduct] = await this.productRepository.findAllWithSellerAndCount(repositoryCondition);
+
+    const totalPageNum = Math.round(count / this.MAX_NUMBER) + 1;
+    const currentPageNum = pageNum + 1;
+
+    if (currentPageNum > totalPageNum) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR);
+    }
+
+    return {
+      products: allProduct,
+      currentPageNum: currentPageNum,
+      totalPageNum: totalPageNum,
+    };
+  }
+
+  async searchProduct(condition: TSellerSearchProductIn): Promise<ISellerFindProductPaging> {
+    const sellerId = condition.sellerId;
+    const text = condition.text;
+    const sortBy = condition.sortBy;
+    const order = condition.order;
+    const pageNum = condition.pageNum - 1;
+
+    if (!this.SORT_BY.includes(sortBy)) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_SORT_BY_OPTION_ERROR);
+    }
+
+    if (!this.ORDER.includes(order)) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_ORDER_OPTION_ERROR);
+    }
+
+    if (!text) {
+      throw new CoPangException(EXCEPTION_STATUS.SEARCH_STRING_EMPTY);
+    }
+
+    if (pageNum < 0) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR);
+    }
+
+    const repositoryCondition: TSellerSearchProductOut = {
+      sellerId: sellerId,
+      text: text,
+      sortBy: sortBy,
+      order: order,
+      skip: pageNum * this.MAX_NUMBER,
+      take: this.MAX_NUMBER,
+    };
+    const [count, allProduct] = await this.productRepository.findSearchWithSellerAndCount(repositoryCondition);
+
+    const totalPageNum = Math.round(count / this.MAX_NUMBER) + 1;
+    const currentPageNum = pageNum + 1;
+
+    if (currentPageNum > totalPageNum) {
+      throw new CoPangException(EXCEPTION_STATUS.PAGING_NUM_ERROR);
+    }
+
+    return {
+      products: allProduct,
+      currentPageNum: currentPageNum,
+      totalPageNum: totalPageNum,
+    };
   }
 }

--- a/src/application/service/seller/seller.service.ts
+++ b/src/application/service/seller/seller.service.ts
@@ -17,6 +17,7 @@ import { IProductRepository } from '../../../domain/service/product/product.repo
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 import { IPasswordEncryptor } from '../../../domain/service/auth/encrypt/password.encryptor';
 import { CoPangException, EXCEPTION_STATUS } from '../../../domain/common/exception';
+import { PAGING_MAX_NUMBER } from '../../../domain/common/const';
 
 @Injectable()
 export class SellerService implements ISellerService {
@@ -26,7 +27,6 @@ export class SellerService implements ISellerService {
     @Inject('IPasswordEncryptor') private passwordEncryptor: IPasswordEncryptor,
   ) {}
 
-  private readonly MAX_NUMBER: number = 20;
   private readonly SORT_BY: string[] = ['id', 'price', 'createdAt'];
   private readonly ORDER: string[] = ['asc', 'desc'];
 
@@ -146,12 +146,12 @@ export class SellerService implements ISellerService {
       sellerId: sellerId,
       sortBy: sortBy,
       order: order,
-      skip: pageNum * this.MAX_NUMBER,
-      take: this.MAX_NUMBER,
+      skip: pageNum * PAGING_MAX_NUMBER,
+      take: PAGING_MAX_NUMBER,
     };
     const [count, allProduct] = await this.productRepository.findAllWithSellerAndCount(repositoryCondition);
 
-    const totalPageNum = Math.round(count / this.MAX_NUMBER) + 1;
+    const totalPageNum = Math.round(count / PAGING_MAX_NUMBER) + 1;
     const currentPageNum = pageNum + 1;
 
     if (currentPageNum > totalPageNum) {
@@ -193,12 +193,12 @@ export class SellerService implements ISellerService {
       text: text,
       sortBy: sortBy,
       order: order,
-      skip: pageNum * this.MAX_NUMBER,
-      take: this.MAX_NUMBER,
+      skip: pageNum * PAGING_MAX_NUMBER,
+      take: PAGING_MAX_NUMBER,
     };
     const [count, allProduct] = await this.productRepository.findSearchWithSellerAndCount(repositoryCondition);
 
-    const totalPageNum = Math.round(count / this.MAX_NUMBER) + 1;
+    const totalPageNum = Math.round(count / PAGING_MAX_NUMBER) + 1;
     const currentPageNum = pageNum + 1;
 
     if (currentPageNum > totalPageNum) {

--- a/src/domain/common/const.ts
+++ b/src/domain/common/const.ts
@@ -1,0 +1,1 @@
+export const PAGING_MAX_NUMBER = 20;

--- a/src/domain/common/exception.ts
+++ b/src/domain/common/exception.ts
@@ -3,6 +3,12 @@ export const EXCEPTION_STATUS = {
   USER_NOT_EXIST: '해당 유저가 존재하지 않습니다.',
   USER_DELETED: '해당 유저는 삭제되었습니다.',
   USER_PASSWORD_NOT_MATCH: '유저의 비밀번호가 일치하지 않습니다.',
+
+  PAGING_NUM_ERROR: '페이징 넘버 에러',
+  PAGING_SORT_BY_OPTION_ERROR: '존재하지 않는 정렬 옵션',
+  PAGING_ORDER_OPTION_ERROR: 'asc or desc 가 아닙니다',
+
+  SEARCH_STRING_EMPTY: '검색조건에 빈칸 입력됨',
 };
 
 export class CoPangException extends Error {

--- a/src/domain/common/exception.ts
+++ b/src/domain/common/exception.ts
@@ -7,8 +7,6 @@ export const EXCEPTION_STATUS = {
   PAGING_NUM_ERROR: '페이징 넘버 에러',
   PAGING_SORT_BY_OPTION_ERROR: '존재하지 않는 정렬 옵션',
   PAGING_ORDER_OPTION_ERROR: 'asc or desc 가 아닙니다',
-
-  SEARCH_STRING_EMPTY: '검색조건에 빈칸 입력됨',
 };
 
 export class CoPangException extends Error {

--- a/src/domain/service/product/product.repository.ts
+++ b/src/domain/service/product/product.repository.ts
@@ -1,5 +1,9 @@
 import { Product } from './product';
+import { SellerProduct, TSellerFindProductOut, TSellerSearchProductOut } from '../seller/seller';
+import { SellerProduct as SellerProductEntity } from '@prisma/client';
 
 export interface IProductRepository {
   findAll: () => Promise<Product[]>;
+  findAllWithSellerAndCount: (condition: TSellerFindProductOut) => Promise<[number, SellerProductEntity[]]>;
+  findSearchWithSellerAndCount: (condition: TSellerSearchProductOut) => Promise<[number, SellerProductEntity[]]>;
 }

--- a/src/domain/service/product/product.repository.ts
+++ b/src/domain/service/product/product.repository.ts
@@ -1,9 +1,9 @@
 import { Product } from './product';
-import { SellerProduct, TSellerFindProductOut, TSellerSearchProductOut } from '../seller/seller';
+import { TSellerFindProductOut } from '../seller/seller';
 import { SellerProduct as SellerProductEntity } from '@prisma/client';
 
 export interface IProductRepository {
   findAll: () => Promise<Product[]>;
-  findAllWithSellerAndCount: (condition: TSellerFindProductOut) => Promise<[number, SellerProductEntity[]]>;
-  findSearchWithSellerAndCount: (condition: TSellerSearchProductOut) => Promise<[number, SellerProductEntity[]]>;
+  findAllWithSeller: (condition: TSellerFindProductOut) => Promise<SellerProductEntity[]>;
+  findAllWithSellerCount: (condition: TSellerFindProductOut) => Promise<number>;
 }

--- a/src/domain/service/product/product.ts
+++ b/src/domain/service/product/product.ts
@@ -1,6 +1,6 @@
-export type Product = {
+export interface Product {
   id: number;
   productName: string;
   productDesc: string;
   deletedAt: Date | null;
-};
+}

--- a/src/domain/service/seller/seller.service.ts
+++ b/src/domain/service/seller/seller.service.ts
@@ -1,4 +1,12 @@
-import { Seller, TSellerSignUpIn, ISellerSignInIn, ISellerChangeInfoIn } from './seller';
+import {
+  Seller,
+  TSellerSignUpIn,
+  ISellerSignInIn,
+  ISellerChangeInfoIn,
+  TSellerFindProductIn,
+  ISellerFindProductPaging,
+  TSellerSearchProductIn,
+} from './seller';
 
 export interface ISellerService {
   signUp: (sellerSignUpIn: TSellerSignUpIn) => Promise<Seller>;
@@ -7,4 +15,6 @@ export interface ISellerService {
   leave: (userId: string) => Promise<Seller>;
   findUser: (userId: string) => Promise<Seller>;
   changeInfo: (changeSeller: ISellerChangeInfoIn) => Promise<Seller>;
+  findProduct: (condition: TSellerFindProductIn) => Promise<ISellerFindProductPaging>;
+  searchProduct: (condition: TSellerSearchProductIn) => Promise<ISellerFindProductPaging>;
 }

--- a/src/domain/service/seller/seller.service.ts
+++ b/src/domain/service/seller/seller.service.ts
@@ -1,12 +1,4 @@
-import {
-  Seller,
-  TSellerSignUpIn,
-  ISellerSignInIn,
-  ISellerChangeInfoIn,
-  TSellerFindProductIn,
-  ISellerFindProductPaging,
-  TSellerSearchProductIn,
-} from './seller';
+import { Seller, TSellerSignUpIn, ISellerSignInIn, ISellerChangeInfoIn, TSellerFindProductIn, ISellerFindProductPaging } from './seller';
 
 export interface ISellerService {
   signUp: (sellerSignUpIn: TSellerSignUpIn) => Promise<Seller>;
@@ -16,5 +8,4 @@ export interface ISellerService {
   findUser: (userId: string) => Promise<Seller>;
   changeInfo: (changeSeller: ISellerChangeInfoIn) => Promise<Seller>;
   findProduct: (condition: TSellerFindProductIn) => Promise<ISellerFindProductPaging>;
-  searchProduct: (condition: TSellerSearchProductIn) => Promise<ISellerFindProductPaging>;
 }

--- a/src/domain/service/seller/seller.ts
+++ b/src/domain/service/seller/seller.ts
@@ -1,3 +1,5 @@
+import { Product } from '../product/product';
+
 export type Seller = {
   id: number;
   userId: string;
@@ -25,3 +27,40 @@ export interface ISellerChangeInfoIn {
 }
 
 export type TSellerChangeInfoOut = Pick<Seller, 'id' | 'userId' | 'ceoName' | 'companyName' | 'password'>;
+
+export interface SellerProduct {
+  id: number;
+  sellerId: number;
+  productId: number;
+  price: number;
+  count: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  Products?: Product;
+}
+
+export type TSellerFindProductIn = {
+  sellerId: number;
+  sortBy: string;
+  order: string;
+  pageNum: number;
+};
+
+export type TSellerFindProductOut = {
+  sellerId: number;
+  sortBy: string;
+  order: string;
+  skip: number;
+  take: number;
+};
+
+export type TSellerSearchProductIn = TSellerFindProductIn & { text: string };
+
+export type TSellerSearchProductOut = TSellerFindProductOut & { text: string };
+
+export interface ISellerFindProductPaging {
+  products: SellerProduct[];
+  currentPageNum: number;
+  totalPageNum: number;
+}

--- a/src/domain/service/seller/seller.ts
+++ b/src/domain/service/seller/seller.ts
@@ -42,22 +42,21 @@ export interface SellerProduct {
 
 export type TSellerFindProductIn = {
   sellerId: number;
+  text: string;
   sortBy: string;
   order: string;
   pageNum: number;
+  take: number;
 };
 
 export type TSellerFindProductOut = {
   sellerId: number;
+  text: string;
   sortBy: string;
   order: string;
   skip: number;
   take: number;
 };
-
-export type TSellerSearchProductIn = TSellerFindProductIn & { text: string };
-
-export type TSellerSearchProductOut = TSellerFindProductOut & { text: string };
 
 export interface ISellerFindProductPaging {
   products: SellerProduct[];

--- a/src/infrastructure/service/product/product.prisma.repository.ts
+++ b/src/infrastructure/service/product/product.prisma.repository.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { Product as ProductEntity } from '@prisma/client';
+import { Product as ProductEntity, SellerProduct as SellerProductEntity } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { IProductRepository } from '../../../domain/service/product/product.repository';
+import { TSellerFindProductOut, TSellerSearchProductOut } from '../../../domain/service/seller/seller';
 
 @Injectable()
 export class ProductPrismaRepository implements IProductRepository {
@@ -9,5 +10,69 @@ export class ProductPrismaRepository implements IProductRepository {
 
   async findAll(): Promise<ProductEntity[]> {
     return await this.prisma.product.findMany({});
+  }
+  async findAllWithSellerAndCount(condition: TSellerFindProductOut): Promise<[number, SellerProductEntity[]]> {
+    const sellerId = condition.sellerId;
+    const orderCondition: { [key: string]: string } = {};
+    orderCondition[condition.sortBy] = condition.order;
+
+    const sellerProductCount = await this.prisma.sellerProduct.count({
+      where: {
+        sellerId: sellerId,
+        deletedAt: null,
+      },
+    });
+
+    const sellerProduct = await this.prisma.sellerProduct.findMany({
+      where: {
+        sellerId: condition.sellerId,
+        deletedAt: null,
+      },
+      orderBy: [orderCondition],
+      include: {
+        Products: true,
+      },
+      skip: condition.skip,
+      take: condition.take,
+    });
+    return [sellerProductCount, sellerProduct];
+  }
+
+  async findSearchWithSellerAndCount(condition: TSellerSearchProductOut): Promise<[number, SellerProductEntity[]]> {
+    const sellerId = condition.sellerId;
+    const text = condition.text;
+    const orderCondition: { [key: string]: string } = {};
+    orderCondition[condition.sortBy] = condition.order;
+
+    const sellerProductCount = await this.prisma.sellerProduct.count({
+      where: {
+        sellerId: sellerId,
+        Products: {
+          productName: {
+            contains: text,
+          },
+        },
+        deletedAt: null,
+      },
+    });
+
+    const sellerProduct = await this.prisma.sellerProduct.findMany({
+      where: {
+        sellerId: condition.sellerId,
+        Products: {
+          productName: {
+            contains: text,
+          },
+        },
+        deletedAt: null,
+      },
+      orderBy: [orderCondition],
+      include: {
+        Products: true,
+      },
+      skip: condition.skip,
+      take: condition.take,
+    });
+    return [sellerProductCount, sellerProduct];
   }
 }

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Inject, Param, Post, Session, UseGuards, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Inject, Param, Post, Query, Session, UseGuards, UseInterceptors } from '@nestjs/common';
 import {
   TSellerLeaveResponse,
   SellerSignInRequest,
@@ -8,8 +8,10 @@ import {
   TSellerFindUserResponse,
   TSellerChangeInfoRequest,
   TSellerChangeInfoResponse,
+  IFindSellerProductResponse,
+  ISellerSearchProductResponse,
 } from './seller.dto';
-import { ISellerChangeInfoIn, TSellerSignUpIn } from '../../../domain/service/seller/seller';
+import { ISellerChangeInfoIn, TSellerFindProductIn, TSellerSearchProductIn, TSellerSignUpIn } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 import { AuthHttpGuard } from '../auth/auth.http.guard';
 import { SessionChangeInfoInterceptor, SessionSignInInterceptor, SessionSignOutInterceptor } from '../auth/auth.interceptor.session';
@@ -100,5 +102,46 @@ export class SellerController {
     };
 
     return sellerInformation;
+  }
+
+  @UseGuards(AuthHttpGuard)
+  @Get('/product/seller/search')
+  async findSellerProductSearch(
+    @Session() session: Record<string, any>,
+    @Query('text') text: string,
+    @Query('sortBy') sortBy = 'id',
+    @Query('order') order = 'desc',
+    @Query('pageNum') pageNum = 1,
+  ) {
+    const sellerId: number = session.user.id;
+    const condition: TSellerSearchProductIn = {
+      sellerId: sellerId,
+      text: text,
+      sortBy: sortBy,
+      order: order,
+      pageNum: pageNum,
+    };
+    const productArray: ISellerSearchProductResponse = await this.sellerService.searchProduct(condition);
+    return productArray;
+  }
+
+  @UseGuards(AuthHttpGuard)
+  @Get('/product/seller')
+  async findSellerProduct(
+    @Session() session: Record<string, any>,
+    @Query('sortBy') sortBy = 'id',
+    @Query('order') order = 'desc',
+    @Query('pageNum') pageNum = 1,
+  ) {
+    const sellerId: number = session.user.id;
+    const productCondition: TSellerFindProductIn = {
+      sellerId: sellerId,
+      sortBy: sortBy,
+      order: order,
+      pageNum: pageNum,
+    };
+    const productArray: IFindSellerProductResponse = await this.sellerService.findProduct(productCondition);
+
+    return productArray;
   }
 }

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -9,12 +9,12 @@ import {
   TSellerChangeInfoRequest,
   TSellerChangeInfoResponse,
   IFindSellerProductResponse,
-  ISellerSearchProductResponse,
 } from './seller.dto';
-import { ISellerChangeInfoIn, TSellerFindProductIn, TSellerSearchProductIn, TSellerSignUpIn } from '../../../domain/service/seller/seller';
+import { ISellerChangeInfoIn, TSellerFindProductIn, TSellerSignUpIn } from '../../../domain/service/seller/seller';
 import { ISellerService } from '../../../domain/service/seller/seller.service';
 import { AuthHttpGuard } from '../auth/auth.http.guard';
 import { SessionChangeInfoInterceptor, SessionSignInInterceptor, SessionSignOutInterceptor } from '../auth/auth.interceptor.session';
+import { PAGING_MAX_NUMBER } from '../../../domain/common/const';
 
 @Controller()
 export class SellerController {
@@ -104,26 +104,28 @@ export class SellerController {
     return sellerInformation;
   }
 
-  @UseGuards(AuthHttpGuard)
-  @Get('/seller/product/search')
-  async findSellerProductSearch(
-    @Session() session: Record<string, any>,
-    @Query('text') text: string,
-    @Query('sortBy') sortBy = 'id',
-    @Query('order') order = 'desc',
-    @Query('pageNum') pageNum = 1,
-  ) {
-    const sellerId: number = session.user.id;
-    const condition: TSellerSearchProductIn = {
-      sellerId: sellerId,
-      text: text,
-      sortBy: sortBy,
-      order: order,
-      pageNum: pageNum,
-    };
-    const productArray: ISellerSearchProductResponse = await this.sellerService.searchProduct(condition);
-    return productArray;
-  }
+  // @UseGuards(AuthHttpGuard)
+  // @Get('/seller/product/search')
+  // async findSellerProductSearch(
+  //   @Session() session: Record<string, any>,
+  //   @Query('text') text: string,
+  //   @Query('sortBy') sortBy = 'id',
+  //   @Query('order') order = 'desc',
+  //   @Query('pageNum') pageNum = 1,
+  //   @Query('take') take = PAGING_MAX_NUMBER,
+  // ) {
+  //   const sellerId: number = session.user.id;
+  //   const condition: TSellerSearchProductIn = {
+  //     sellerId: sellerId,
+  //     text: text,
+  //     sortBy: sortBy,
+  //     order: order,
+  //     pageNum: pageNum,
+  //     take: take,
+  //   };
+  //   const productArray: ISellerSearchProductResponse = await this.sellerService.searchProduct(condition);
+  //   return productArray;
+  // }
 
   @UseGuards(AuthHttpGuard)
   @Get('/seller/product')
@@ -131,14 +133,18 @@ export class SellerController {
     @Session() session: Record<string, any>,
     @Query('sortBy') sortBy = 'id',
     @Query('order') order = 'desc',
+    @Query('text') text = '',
     @Query('pageNum') pageNum = 1,
+    @Query('take') take = PAGING_MAX_NUMBER,
   ) {
     const sellerId: number = session.user.id;
     const productCondition: TSellerFindProductIn = {
       sellerId: sellerId,
+      text: text,
       sortBy: sortBy,
       order: order,
       pageNum: pageNum,
+      take: take,
     };
     const productArray: IFindSellerProductResponse = await this.sellerService.findProduct(productCondition);
 

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -52,6 +52,7 @@ export class SellerController {
     const seller = await this.sellerService.signIn(signInSellerRequest);
 
     const response: TSellerSignInResponse = {
+      id: seller.id,
       userId: seller.userId,
       ceoName: seller.ceoName,
       companyName: seller.companyName,

--- a/src/infrastructure/service/seller/seller.controller.ts
+++ b/src/infrastructure/service/seller/seller.controller.ts
@@ -105,7 +105,7 @@ export class SellerController {
   }
 
   @UseGuards(AuthHttpGuard)
-  @Get('/product/seller/search')
+  @Get('/seller/product/search')
   async findSellerProductSearch(
     @Session() session: Record<string, any>,
     @Query('text') text: string,
@@ -126,7 +126,7 @@ export class SellerController {
   }
 
   @UseGuards(AuthHttpGuard)
-  @Get('/product/seller')
+  @Get('/seller/product')
   async findSellerProduct(
     @Session() session: Record<string, any>,
     @Query('sortBy') sortBy = 'id',

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -66,9 +66,3 @@ export interface IFindSellerProductResponse {
   currentPageNum: number;
   totalPageNum: number;
 }
-
-export interface ISellerSearchProductResponse {
-  products: SellerProduct[];
-  currentPageNum: number;
-  totalPageNum: number;
-}

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, IsNotEmpty, Matches } from 'class-validator';
-import { Seller } from '../../../domain/service/seller/seller';
+import { Seller, SellerProduct } from '../../../domain/service/seller/seller';
 
 export class TSellerSignUpRequest {
   @IsString()
@@ -60,3 +60,15 @@ export class TSellerChangeInfoRequest {
 }
 
 export type TSellerChangeInfoResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
+
+export interface IFindSellerProductResponse {
+  products: SellerProduct[];
+  currentPageNum: number;
+  totalPageNum: number;
+}
+
+export interface ISellerSearchProductResponse {
+  products: SellerProduct[];
+  currentPageNum: number;
+  totalPageNum: number;
+}

--- a/src/infrastructure/service/seller/seller.dto.ts
+++ b/src/infrastructure/service/seller/seller.dto.ts
@@ -33,7 +33,7 @@ export class SellerSignInRequest {
   password: string;
 }
 
-export type TSellerSignInResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
+export type TSellerSignInResponse = Pick<Seller, 'id' | 'userId' | 'ceoName' | 'companyName'>;
 
 export type TSellerLeaveResponse = Pick<Seller, 'userId' | 'ceoName' | 'companyName'>;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './infrastructure/app.module';
 import * as session from 'express-session';
 import { HttpExceptionFilter } from './infrastructure/service/common/http-exception.filter';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -13,6 +14,7 @@ async function bootstrap() {
     }),
   );
   app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
- 판매자의 판매상품 불러오기
    - GET /seller/product/search
- 판매자의 판매 상품 찾기
    - GET /seller/product
 
## 고민사항
* 판매 물품 조회 API 와 판매 물품을 검색 paging을 나누어 API를 개발하였음.
    * 테스트코드를 작성하다보니 두 API가 상당히 유사한거 같아 보임
    * 이러한 중복이 보인다면 보통 하나로 개발하나? 하는 고민이 듬
    * 해당 PR 에서는 물품 조회, 검색 조회 두개로 개발 함

* Notion 링크
https://www.notion.so/gweongi/COP-6-Read-e7cc99fc3c474c788e45e87970fca2ab